### PR TITLE
feat: adicionar suporte a Swagger/OpenAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,14 @@ mvn clean install
 mvn spring-boot:run
 ```
 
-4. Acesse a API em:
+4. Documentação Swagger/OpenAPI disponível em:
+
+```
+http://localhost:8080/swagger-ui.html
+http://localhost:8080/api-docs
+```
+
+5. Acesse a API em:
 
 ```
 http://localhost:8080/api/clientes
@@ -199,7 +206,7 @@ mvn test
 * [ ] 🏠 **Integrar API do ViaCEP** para preencher e validar endereços automaticamente ao criar ou atualizar clientes.
   Fonte: [ViaCEP - API](https://viacep.com.br/)
 * [ ] 🔒 **Adicionar autenticação JWT** para proteger os endpoints da API.
-* [ ] 📑 **Documentar a API com Swagger / OpenAPI** para facilitar testes e integração com outros sistemas.
+* [x] 📑 **Documentar a API com Swagger / OpenAPI** para facilitar testes e integração com outros sistemas.
 * [ ] 🐘 **Substituir H2 por PostgreSQL** ou outro banco relacional para persistência em produção.
 * [ ] 🧪 **Adicionar testes de integração** que validem fluxos completos da API.
 * [ ] ✅ **Adicionar validações avançadas de campos** como email, telefone e CPF.
@@ -217,7 +224,7 @@ mvn test
 
 * O projeto segue o **padrão Clean Architecture**, com camadas separadas para **domínio**, **aplicação**, **infraestrutura** e **interfaces**.
 * Banco H2 é **volátil** (dados desaparecem ao parar a aplicação). Para produção, substituir por **PostgreSQL** ou outro banco relacional.
-* Preparado para **adicionar autenticação JWT** e **documentação Swagger/OpenAPI** futuramente. 🔐📑
+* Preparado para **adicionar autenticação JWT** e já conta com **documentação Swagger/OpenAPI** para facilitar integrações. 🔐📑
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ mvn test
 * [ ] 🧪 **Adicionar testes de integração** que validem fluxos completos da API.
 * [ ] ✅ **Adicionar validações avançadas de campos** como email, telefone e CPF.
 * [ ] 🔀 **Implementar mapeamento DTO ↔ Entity com MapStruct** para reduzir boilerplate.
-* [ ] 🔀 **Implementar uma autenticação de dois fatores para a confirmação do email.
+* [ ] 🔀 **Implementar uma autenticação de dois fatores para a confirmação do email**.
 
 ### ***Indicadores de Conclusão***
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.13</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/github/diegolins10/clientapi/api/config/OpenApiConfig.java
+++ b/src/main/java/com/github/diegolins10/clientapi/api/config/OpenApiConfig.java
@@ -1,0 +1,23 @@
+package com.github.diegolins10.clientapi.api.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI clientApiOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Client Integration API")
+                        .description("Documentação da API de gerenciamento de clientes")
+                        .version("v1")
+                        .contact(new Contact().name("Equipe Client API"))
+                        .license(new License().name("MIT")));
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,5 @@ spring.datasource.username=sa
 spring.datasource.password=
 spring.h2.console.enabled=true
 spring.jpa.hibernate.ddl-auto=update
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.api-docs.path=/api-docs


### PR DESCRIPTION
### Motivation

- Fornecer documentação automática da API para facilitar testes e integrações externas usando OpenAPI/Swagger.

### Description

- Adiciona a dependência `org.springdoc:springdoc-openapi-starter-webmvc-ui` no `pom.xml` para habilitar Swagger UI e endpoints OpenAPI.
- Cria a configuração `OpenApiConfig` em `src/main/java/.../api/config/OpenApiConfig.java` com metadados (título, descrição, versão, contato e licença) para a especificação OpenAPI.
- Expõe os caminhos da documentação ajustando `src/main/resources/application.properties` com `springdoc.swagger-ui.path=/swagger-ui.html` e `springdoc.api-docs.path=/api-docs`.
- Atualiza o `README.md` com links para `http://localhost:8080/swagger-ui.html` e `http://localhost:8080/api-docs` e marca a tarefa de documentação como concluída.

### Testing

- Executado `./mvnw test` que falhou devido a limitação de ambiente ao baixar o Maven wrapper (`Failed to fetch ... apache-maven-3.9.11-bin.zip`).
- Executado `mvn test` que falhou ao resolver dependências no Maven Central com erro `403 Forbidden` ao buscar `org.springframework.boot:spring-boot-starter-parent:3.5.6`, portanto nenhum teste automatizado do projeto foi executado com sucesso neste ambiente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3af1f138c8326bb8711133b49e414)